### PR TITLE
[feature] Automatically switch-on Roots tab on first root pinned.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    if: ${{ ! startsWith(github.actor, 'dependabot') }}
+    environment: Development
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -22,6 +24,21 @@ jobs:
 
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1.0.5
+
+
+    - name: Decrypt the keystore for signing
+      run: |
+        echo "${{ secrets.KEYSTORE_ENCRYPTED }}" > keystore.asc
+        gpg -d --passphrase "${{ secrets.KEYSTORE_PASSWORD }}" --batch keystore.asc > keystore.jks
       
     - name: Build components
       run: ./gradlew assembleRelease
+
+    - name: Build release sample APK
+      run: ./gradlew sample:assembleRelease
+
+    - name: Upload release APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-universal-apk
+        path: ./sample/build/outputs/apk/release/sample-release.apk

--- a/components/src/main/java/dev/arkbuilders/components/filepicker/callback/PinFileCallback.kt
+++ b/components/src/main/java/dev/arkbuilders/components/filepicker/callback/PinFileCallback.kt
@@ -1,7 +1,0 @@
-package dev.arkbuilders.components.filepicker.callback
-
-import java.nio.file.Path
-
-interface PinFileCallback {
-    fun onPinFileClick(file: Path)
-}

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -17,9 +17,19 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = project.rootProject.file("keystore.jks")
+            storePassword = "sw0rdf1sh"
+            keyAlias = "ark-builders-test"
+            keyPassword = "rybamech"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
* Automatically switch-on Roots tab on first root pinned  

* Remember user's last selected tab 

* Setup deployment pipeline for publishing the `sample` app, which depicts usages of the `filepicker` module.
 
 Ticket: https://github.com/ARK-Builders/ark-components/issues/51