### PR TITLE
Prohibit nested roots

### DIFF
--- a/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerFragment.kt
+++ b/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerFragment.kt
@@ -306,6 +306,10 @@ open class ArkFilePickerFragment :
         FilePickerSideEffect.CannotPinFile -> {
             activity?.toast(R.string.ark_file_picker_pin_folder_only)
         }
+
+        FilePickerSideEffect.NestedRootProhibited -> {
+            activity?.toast(R.string.ark_file_nested_root_inside)
+        }
     }
 
 

--- a/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerViewModel.kt
+++ b/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerViewModel.kt
@@ -14,6 +14,7 @@ import org.orbitmvi.orbit.viewmodel.container
 import dev.arkbuilders.arklib.data.folders.FoldersRepo
 import dev.arkbuilders.arklib.utils.DeviceStorageUtils
 import dev.arkbuilders.arklib.utils.listChildren
+import dev.arkbuilders.components.utils.hasNestedOrParentalRoot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.nio.file.Path
@@ -192,10 +193,7 @@ internal class ArkFilePickerViewModel(
         val root = roots.find { root -> file.startsWith(root) }
         val favorites = rootsWithFavorites[root]?.flatten()
 
-        val hasNestedRoot = roots.contains(file)
-                || (roots.indexOfFirst { path ->
-                    val index = path.toString().indexOf(file.toString())
-                    (index >= 0) && (path.toString()[index] == '/') } >= 0)
+        val hasNestedRoot = file.hasNestedOrParentalRoot(roots)
 
         if (hasNestedRoot) {
             postSideEffect(FilePickerSideEffect.NestedRootProhibited)

--- a/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerViewModel.kt
+++ b/filepicker/src/main/java/dev/arkbuilders/components/filepicker/ArkFilePickerViewModel.kt
@@ -44,6 +44,7 @@ internal sealed class FilePickerSideEffect {
     data object AlreadyFavorite : FilePickerSideEffect()
     data object PinAsFirstRoot : FilePickerSideEffect()
     data object CannotPinFile : FilePickerSideEffect()
+    data object NestedRootProhibited : FilePickerSideEffect()
 
 }
 
@@ -190,6 +191,17 @@ internal class ArkFilePickerViewModel(
         val roots = rootsWithFavorites.keys
         val root = roots.find { root -> file.startsWith(root) }
         val favorites = rootsWithFavorites[root]?.flatten()
+
+        val hasNestedRoot = roots.contains(file)
+                || (roots.indexOfFirst { path ->
+                    val index = path.toString().indexOf(file.toString())
+                    (index >= 0) && (path.toString()[index] == '/') } >= 0)
+
+        if (hasNestedRoot) {
+            postSideEffect(FilePickerSideEffect.NestedRootProhibited)
+            return@intent
+        }
+
         val haveRoot = haveRoot()
 
         root?.let {

--- a/filepicker/src/main/res/values/strings.xml
+++ b/filepicker/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="ark_file_picker_already_a_favorite">Already be a Favorite folder!</string>
     <string name="ark_file_picker_already_be_a_root">Already be a Root folder!</string>
     <string name="ark_file_picker_pin_folder_only">Only folder can be pinned.</string>
+    <string name="ark_file_nested_root_inside">There\'s already nested root(s) inside.</string>
     <string name="ark_file_picker_pin">Pin</string>
     <plurals name="ark_file_picker_items">
         <item quantity="one">%d item</item>

--- a/utils/src/main/java/dev/arkbuilders/components/utils/PathExt.kt
+++ b/utils/src/main/java/dev/arkbuilders/components/utils/PathExt.kt
@@ -1,0 +1,10 @@
+package dev.arkbuilders.components.utils
+
+import java.nio.file.Path
+
+fun Path.hasNestedOrParentalRoot(roots: Iterable<Path>): Boolean {
+    val hasNestedRoot = roots.any { path ->
+        this.startsWith(path) || path.startsWith(this)
+    }
+    return hasNestedRoot
+}

--- a/utils/src/test/java/dev/arkbuilders/components/utils/PathExtTest.kt
+++ b/utils/src/test/java/dev/arkbuilders/components/utils/PathExtTest.kt
@@ -1,0 +1,132 @@
+package dev.arkbuilders.components.utils
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class PathExtTest {
+
+    // --- Tests with Set for roots parameter ---
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when there is an exact match in roots`() {
+        val path = Paths.get("/parent/child")
+        val roots = setOf(Paths.get("/parent/child"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when there is a direct parent in roots`() {
+        val path = Paths.get("/parent/child")
+        val roots = setOf(Paths.get("/parent"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when there is a direct child in roots`() {
+        val path = Paths.get("/parent")
+        val roots = setOf(Paths.get("/parent/child"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when there is a nested parent in roots`() {
+        val path = Paths.get("/parent/child/grandchild")
+        val roots = setOf(Paths.get("/parent"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when there is a nested child in roots`() {
+        val path = Paths.get("/parent")
+        val roots = setOf(Paths.get("/parent/child/grandchild"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return false when there are no nested or parental roots`() {
+        val path = Paths.get("/parent/child")
+        val roots = setOf(Paths.get("/unrelated"), Paths.get("/another"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), false)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return false when roots set is empty`() {
+        val path = Paths.get("/parent/child")
+        val roots = emptySet<Path>()
+        assertEquals(path.hasNestedOrParentalRoot(roots), false)
+    }
+
+    // --- Tests with List for roots parameter ---
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when an exact match exists in roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/parent/child"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when a direct parent exists in roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/parent"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when a direct child exists in roots (List)`() {
+        val path = Paths.get("/parent")
+        val roots = listOf(Paths.get("/parent/child"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when a nested parent exists in roots (List)`() {
+        val path = Paths.get("/parent/child/grandchild")
+        val roots = listOf(Paths.get("/parent"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return false when there are no nested or parental roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/unrelated"), Paths.get("/another"))
+        assertEquals(path.hasNestedOrParentalRoot(roots), false)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return false when roots is empty`() {
+        val path = Paths.get("/parent/child")
+        val roots = emptyList<Path>()
+        assertEquals(path.hasNestedOrParentalRoot(roots), false)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when duplicates of an exact match exist in roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/parent/child"), Paths.get("/parent/child")) // Duplicate exact match
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when duplicates of a direct parent exist in roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/parent"), Paths.get("/parent")) // Duplicate direct parent
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return true when duplicates of a nested parent exist in roots (List)`() {
+        val path = Paths.get("/parent/child/grandchild")
+        val roots = listOf(Paths.get("/parent"), Paths.get("/parent")) // Duplicate nested parent
+        assertEquals(path.hasNestedOrParentalRoot(roots), true)
+    }
+
+    @Test
+    fun `hasNestedOrParentalRoot should return false when duplicates of unrelated paths exist in roots (List)`() {
+        val path = Paths.get("/parent/child")
+        val roots = listOf(Paths.get("/unrelated"), Paths.get("/unrelated")) // Duplicate unrelated paths
+        assertEquals(path.hasNestedOrParentalRoot(roots), false)
+    }
+}


### PR DESCRIPTION
### Description:

Prohibit nested roots: https://github.com/ARK-Builders/ark-android/issues/68

For the duplicated logic removal of [RootPickerDialogFragment](https://github.com/ARK-Builders/ARK-Navigator/blob/main/app/src/main/java/dev/arkbuilders/navigator/presentation/dialog/RootPickerDialogFragment.kt), or to be exact, `FoldersViewModel`, it should be done in `Navigator` repository. 
An in-progress work is here: https://github.com/ARK-Builders/ARK-Navigator/pull/441

### Before

https://github.com/user-attachments/assets/42082261-6ca3-4abe-aa26-51f2e2eb6a0b


### After

https://github.com/user-attachments/assets/a2b7dd74-33b2-4840-a5f0-4c0994b7531d

