### PR TITLE
Avoid manual modules version management inside repo

### DIFF
--- a/filepicker/build.gradle.kts
+++ b/filepicker/build.gradle.kts
@@ -46,10 +46,8 @@ android {
 }
 
 dependencies {
-    implementation(libraries.ark.component.utils)
-    implementation(libraries.ark.component.folderstree)
-    implementation(libraries.ark.component.tagselector)
-    implementation(libraries.ark.component.scorewidget)
+    implementation(project(":utils"))
+    implementation(project(":folderstree"))
 
     implementation(libraries.androidx.core.ktx)
     implementation(libraries.androidx.appcompat)

--- a/folderstree/build.gradle.kts
+++ b/folderstree/build.gradle.kts
@@ -41,8 +41,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":utils"))
 
-    implementation(libraries.ark.component.utils)
     implementation(libraries.androidx.core.ktx)
     implementation(libraries.androidx.appcompat)
     implementation(libraries.android.material)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,4 @@
 [versions]
-arkComponentUtils = "0.0.9-SNAPSHOT-01"
-arkComponentFoldersTree = "0.0.9-SNAPSHOT-02"
-arkComponentTagSelector = "0.0.9-SNAPSHOT-02"
-arkComponentScoreWidget = "0.0.9-SNAPSHOT-02"
-arkComponentFilePicker = "0.1.0-SNAPSHOT"
 coil = "2.4.0"
 androidxFragmentKtx = "1.6.1"
 fastadapter = "5.7.0"
@@ -20,11 +15,6 @@ skydovesBalloon = "1.6.4"
 flexbox = "3.0.0"
 
 [libraries]
-ark-component-utils = { group = "dev.arkbuilders.components", name = "utils", version.ref = "arkComponentUtils" }
-ark-component-folderstree = { group = "dev.arkbuilders.components", name = "folderstree", version.ref = "arkComponentFoldersTree" }
-ark-component-tagselector = { group = "dev.arkbuilders.components", name = "tagselector", version.ref = "arkComponentTagSelector" }
-ark-component-scorewidget = { group = "dev.arkbuilders.components", name = "scorewidget", version.ref = "arkComponentScoreWidget" }
-ark-component-filepicker = { group = "dev.arkbuilders.components", name = "filepicker", version.ref = "arkComponentFilePicker" }
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
 coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -69,9 +69,9 @@ android {
 }
 
 dependencies {
-    implementation(libraries.ark.component.filepicker)
-    implementation(libraries.arklib)
+    implementation(project(":filepicker"))
 
+    implementation(libraries.arklib)
     implementation("androidx.core:core-ktx:1.12.0")
     implementation(libraries.androidx.appcompat)
     implementation(libraries.android.material)

--- a/tagselector/build.gradle.kts
+++ b/tagselector/build.gradle.kts
@@ -41,8 +41,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":utils"))
 
-    implementation(libraries.ark.component.utils)
     implementation(libraries.androidx.core.ktx)
     implementation(libraries.androidx.appcompat)
     implementation(libraries.android.material)


### PR DESCRIPTION
Now we have to manually manage versions so that they comply with the artifacts versions from Github.
Which is difficult and for example now they don’t match. And the project is not building.
```
arkComponentUtils = "0.0.9-SNAPSHOT-01"
arkComponentFoldersTree = "0.0.9-SNAPSHOT-02"
arkComponentTagSelector = "0.0.9-SNAPSHOT-02"
arkComponentScoreWidget = "0.0.9-SNAPSHOT-02"
arkComponentFilePicker = "0.1.0-SNAPSHOT"
```
https://github.com/ARK-Builders/ark-android/blob/main/gradle/libs.versions.toml
https://github.com/orgs/ARK-Builders/packages?repo_name=ark-android

I propose to make modules dependent directly on project and not on artifacts from Github