### PR TITLE
[Build] Fix build error due to missing icon drawable resource in sample app

### DIFF
--- a/sample/src/main/res/drawable/ic_close.xml
+++ b/sample/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>


### PR DESCRIPTION
**Error:**

https://github.com/ARK-Builders/ark-android/actions/runs/9035141685/job/24829270082

**Cause:**

`dev.arkbuilders.sample-mergeReleaseResources-44:/layout/dialog_map_entry.xml:29: error: resource drawable/ic_close (aka dev.arkbuilders.sample:drawable/ic_close) not found.`