### PR TITLE
Rust JNI FileStorage bindings sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,39 @@ git push --tags
 - Create an action build file under `.github/workflows/` folder, following any existing build script.
 - Create a release build file under `.github/workflows/` folder, following any existing release script.
 
+## Making the Storage Demo work
+
+This section guides you through setting up and running the Storage Demo subpage.
+
+**1. Download the `fs-storage` JNI Libraries:**
+
+The demo requires JNI libraries (libs).  Download these from the following location:
+
+* **[ark-core repository](https://github.com/ARK-Builders/ark-core)**
+
+    - If you can't find them in the "Releases" section, check the latest successful build actions for artifacts.
+
+**2. Place the Libraries:**
+
+After downloading, move the JNI library files into your project's `sample/src/main/jniLibs` directory. **If the path doesn't exist, create it**
+
+Your project structure should resemble this:
+
+```
+...
+sample/
+    ...
+    src/
+        main/
+            ...
+            jniLibs/
+                arm64-v8a/  
+                armeabi-v7a/
+                x86/
+                x86_64/
+            ...
+        ...
+    ...
+```
+
+With the `fs-storage` JNI libraries in place, you're ready to build, run the project and use the Storage Demo subpage.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ fastadapter = { group = "com.mikepenz", name = "fastadapter", version.ref = "fas
 fastadapter-extensions-binding = { group = "com.mikepenz", name = "fastadapter-extensions-binding", version.ref = "fastadapter" }
 fastadapter-extensions-diff = { group = "com.mikepenz", name = "fastadapter-extensions-diff", version.ref = "fastadapter" }
 arklib = { group = "dev.arkbuilders", name = "arklib", version.ref = "arkLib" }
+core = {group = "dev.arkbuilders.core", name = "lib", version = "1.0-SNAPSHOT"}
 orbit-mvi-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbitMvi" }
 viewbinding-property-delegate = { group = "com.github.kirich1409", name = "viewbindingpropertydelegate-noreflection", version.ref = "viewbindingPropertyDelegate" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidXCore" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(project(":filepicker"))
     implementation(project(":about"))
 
+    implementation("dev.arkbuilders.core:lib:1.0-SNAPSHOT")
     implementation(libraries.arklib)
     implementation("androidx.core:core-ktx:1.12.0")
     implementation(libraries.androidx.appcompat)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -80,4 +80,11 @@ dependencies {
     testImplementation(libraries.junit)
     androidTestImplementation(libraries.androidx.test.junit)
     androidTestImplementation(libraries.androidx.test.espresso)
+    runtimeOnly(
+        fileTree(
+            mapOf(
+                "dir" to "src/main/jniLibs",
+            )
+        )
+    )
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -72,8 +72,7 @@ android {
 dependencies {
     implementation(project(":filepicker"))
     implementation(project(":about"))
-
-    implementation("dev.arkbuilders.core:lib:1.0-SNAPSHOT")
+    implementation(libraries.core)
     implementation(libraries.arklib)
     implementation("androidx.core:core-ktx:1.12.0")
     implementation(libraries.androidx.appcompat)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,8 +16,16 @@ dependencyResolutionManagement {
             url = URI("https://jitpack.io")
         }
         maven {
-            name = "GitHubPackages"
+            name = "arklib-android GitHub Packages"
             url = URI("https://maven.pkg.github.com/ARK-Builders/arklib-android")
+            credentials {
+                username = "token"
+                password = "\u0037\u0066\u0066\u0036\u0030\u0039\u0033\u0066\u0032\u0037\u0033\u0036\u0033\u0037\u0064\u0036\u0037\u0066\u0038\u0030\u0034\u0039\u0062\u0030\u0039\u0038\u0039\u0038\u0066\u0034\u0066\u0034\u0031\u0064\u0062\u0033\u0064\u0033\u0038\u0065"
+            }
+        }
+        maven {
+            name = "ark-core GitHub Packages"
+            url = URI("https://maven.pkg.github.com/ARK-Builders/ark-core")
             credentials {
                 username = "token"
                 password = "\u0037\u0066\u0066\u0036\u0030\u0039\u0033\u0066\u0032\u0037\u0033\u0036\u0033\u0037\u0064\u0036\u0037\u0066\u0038\u0030\u0034\u0039\u0062\u0030\u0039\u0038\u0039\u0038\u0066\u0034\u0066\u0034\u0031\u0064\u0062\u0033\u0064\u0033\u0038\u0065"


### PR DESCRIPTION
This pull request introduces an interactive sample application demonstrating the use of the Rust bindings for the `FileStorage`, from the `fs-storage`. 

The application features two dialogs:

1. **Root Directory Selection:** Allows the user to choose a specific directory as the storage root.
2. **File Scoring Dialog:** Enables users to select files from the chosen root directory and assign individual scores to them.

All calculated scores for the selected root directory are then saved to a file named `storage.txt` located within the same root directory