### PR TITLE
Upgrade GitHub Actions Artifacts to v4

### DIFF
--- a/.github/workflows/build_about.yml
+++ b/.github/workflows/build_about.yml
@@ -43,19 +43,19 @@ jobs:
       run: ./gradlew sample:assembleRelease
 
     - name: Upload release arm64-v8a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-arm64-v8a-apk
         path: ./sample/build/outputs/apk/release/sample-arm64-v8a-release.apk
 
     - name: Upload release armeabi-v7a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-armeabi-v7a-apk
         path: ./sample/build/outputs/apk/release/sample-armeabi-v7a-release.apk
 
     - name: Upload release universal APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-universal-apk
         path: ./sample/build/outputs/apk/release/sample-universal-release.apk

--- a/.github/workflows/build_filepicker.yml
+++ b/.github/workflows/build_filepicker.yml
@@ -43,19 +43,19 @@ jobs:
       run: ./gradlew sample:assembleRelease
 
     - name: Upload release arm64-v8a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-arm64-v8a-apk
         path: ./sample/build/outputs/apk/release/sample-arm64-v8a-release.apk
 
     - name: Upload release armeabi-v7a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-armeabi-v7a-apk
         path: ./sample/build/outputs/apk/release/sample-armeabi-v7a-release.apk
 
     - name: Upload release universal APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-universal-apk
         path: ./sample/build/outputs/apk/release/sample-universal-release.apk

--- a/.github/workflows/build_sample.yml
+++ b/.github/workflows/build_sample.yml
@@ -40,19 +40,19 @@ jobs:
       run: ./gradlew sample:assembleRelease
 
     - name: Upload release arm64-v8a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-arm64-v8a-apk
         path: ./sample/build/outputs/apk/release/sample-arm64-v8a-release.apk
 
     - name: Upload release armeabi-v7a APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-armeabi-v7a-apk
         path: ./sample/build/outputs/apk/release/sample-armeabi-v7a-release.apk
 
     - name: Upload release universal APK
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-universal-apk
         path: ./sample/build/outputs/apk/release/sample-universal-release.apk


### PR DESCRIPTION
Upgrade GitHub Actions Artifacts to v4.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/